### PR TITLE
Fix hang on main thread exceptions

### DIFF
--- a/android/src/main/java/com/magicleap/rnxrclient/XrClientSession.kt
+++ b/android/src/main/java/com/magicleap/rnxrclient/XrClientSession.kt
@@ -340,13 +340,14 @@ class XrClientSession {
         mainThreadHandler.post {
             try {
                 task()
-                done.open()
             } catch (t: Throwable) {
                 ex = t
+            } finally {
+                done.open()
             }
         }
         if (!done.block(30 * 1000)) {
-            throw TimeoutException()
+            throw TimeoutException("Timed out waiting for main thread task")
         }
         ex?.let {
             throw it


### PR DESCRIPTION
This was also resulting in a "null" error message instead of showing the actual exception that occurred (making debugging quite painful).